### PR TITLE
Add GraphQL queries and services for multiple entities

### DIFF
--- a/EkofyApp.Api/GraphQL/Mutation/Entitlements/EntitlementMutation.cs
+++ b/EkofyApp.Api/GraphQL/Mutation/Entitlements/EntitlementMutation.cs
@@ -1,6 +1,5 @@
 ﻿using EkofyApp.Application.Models.Entitlements;
 using EkofyApp.Application.ServiceInterfaces.Entitlements;
-using EkofyApp.Domain.Entities;
 
 namespace EkofyApp.Api.GraphQL.Mutation.Entitlements;
 
@@ -9,11 +8,6 @@ namespace EkofyApp.Api.GraphQL.Mutation.Entitlements;
 public sealed class EntitlementMutation(IEntitlementService entitlementService)
 {
     private readonly IEntitlementService _entitlementService = entitlementService;
-
-    public IQueryable<Entitlement> GetEntitlements()
-    {
-        return _entitlementService.GetEntitlements();
-    }
 
     public async Task<bool> SeedEntitlementsAsync(string password)
     {

--- a/EkofyApp.Api/GraphQL/Mutation/Entitlements/EntitlementMutationExtension.cs
+++ b/EkofyApp.Api/GraphQL/Mutation/Entitlements/EntitlementMutationExtension.cs
@@ -4,9 +4,6 @@ public sealed class EntitlementMutationExtension : ObjectTypeExtension<Entitleme
 {
     protected override void Configure(IObjectTypeDescriptor<EntitlementMutation> descriptor)
     {
-        descriptor.Field(x => x.GetEntitlements())
-            .Authorize(roles: "Admin");
-
         descriptor.Field(x => x.SeedEntitlementsAsync(default!))
             .Authorize(roles: "Admin");
             //.AllowAnonymous();

--- a/EkofyApp.Api/GraphQL/Query/Categories/CategoryQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Categories/CategoryQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Categories;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Categories;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class CategoryQuery(ICategoryService categoryService)
+{
+    private readonly ICategoryService _categoryService = categoryService;
+
+    public IQueryable<Category> GetCategories()
+    {
+        return _categoryService.GetCategories();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Entitlements;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Entitlements;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class EntitlementQuery(IEntitlementService entitlementService)
+{
+    private readonly IEntitlementService _entitlementService = entitlementService;
+
+    public IQueryable<Entitlement> GetEntitlements()
+    {
+        return _entitlementService.GetEntitlements();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Entitlements;
+
+public sealed class EntitlementQueryExtension : ObjectTypeExtension<EntitlementQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<EntitlementQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetEntitlements())
+            .Authorize(roles: "Admin");
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQuery.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Invoices;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Invoices;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class InvoiceQuery(IInvoiceService invoiceService)
+{
+    private readonly IInvoiceService _invoiceService = invoiceService;
+    public IQueryable<Invoice> GetInvoices()
+    {
+        return _invoiceService.GetInvoices();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Invoices;
+
+public sealed class InvoiceQueryExtension : ObjectTypeExtension<InvoiceQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<InvoiceQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetInvoices())
+            .Authorize(roles: ["Listener", "Artist", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Listeners;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Listeners;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class ListenerQuery(IListenerService listenerService)
+{
+    private readonly IListenerService _listenerService = listenerService;
+
+    public IQueryable<Listener> GetListeners()
+    {
+        return _listenerService.GetListeners();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Listeners;
+
+public sealed class ListenerQueryExtension : ObjectTypeExtension<ListenerQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<ListenerQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetListeners())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.MonthlyStreamCounts;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class MonthlyStreamCountQuery(IMonthlyStreamCountService monthlyStreamCountService)
+{
+    private readonly IMonthlyStreamCountService _monthlyStreamCountService = monthlyStreamCountService;
+
+    public IQueryable<MonthlyStreamCount> GetMonthlyStreamCounts()
+    {
+        return _monthlyStreamCountService.GetMonthlyStreamCounts();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.MonthlyStreamCounts;
+
+public sealed class MonthlyStreamCountQueryExtension : ObjectTypeExtension<MonthlyStreamCountQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<MonthlyStreamCountQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetMonthlyStreamCounts())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Playlists;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Playlists;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class PlaylistQuery(IPlaylistService playlistService)
+{
+    private readonly IPlaylistService _playlistService = playlistService;
+
+    public IQueryable<Playlist> GetPlaylists()
+    {
+        return _playlistService.GetPlaylists();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Playlists;
+
+public sealed class PlaylistQueryExtension : ObjectTypeExtension<PlaylistQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<PlaylistQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetPlaylists())
+            .Authorize(roles: ["Listener", "Artist"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Policies;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Policies;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class LegalPolicyQuery(ILegalPolicyService legalPolicyService)
+{
+    private readonly ILegalPolicyService _legalPolicyService = legalPolicyService;
+
+    public IQueryable<LegalPolicy> GetLegalPolicies()
+    {
+        return _legalPolicyService.GetLegalPolicies();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Policies;
+
+public sealed class LegalPolicyQueryExtension : ObjectTypeExtension<LegalPolicyQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<LegalPolicyQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetLegalPolicies())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Policies;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Policies;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class RoyaltyPolicyQuery(IRoyaltyPolicyService royaltyPolicyService)
+{
+    private readonly IRoyaltyPolicyService _royaltyPolicyService = royaltyPolicyService;
+
+    public IQueryable<RoyaltyPolicy> GetRoyaltyPolicies()
+    {
+        return _royaltyPolicyService.GetRoyaltyPolicies();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Policies;
+
+public sealed class RoyaltyPolicyQueryExtension : ObjectTypeExtension<RoyaltyPolicyQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<RoyaltyPolicyQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetRoyaltyPolicies())
+            .Authorize(roles: "Admin");
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.RoyaltyReports;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.RoyalReports;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class RoyaltyReportQuery(IRoyaltyReportService royaltyReportService)
+{
+    private readonly IRoyaltyReportService _royaltyReportService = royaltyReportService;
+
+    public IQueryable<RoyaltyReport> GetRoyaltyReports()
+    {
+        return _royaltyReportService.GetRoyaltyReports();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.RoyalReports;
+
+public sealed class RoyaltyReportQueryExtension : ObjectTypeExtension<RoyaltyReportQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<RoyaltyReportQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetRoyaltyReports())
+            .Authorize(roles: ["Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Subscriptions;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class SubscriptionPlanQuery(ISubscriptionPlanService subscriptionPlanService)
+{
+    private readonly ISubscriptionPlanService _subscriptionPlanService = subscriptionPlanService;
+
+    public IQueryable<SubscriptionPlan> GetSubscriptionPlans()
+    {
+        return _subscriptionPlanService.GetSubscriptionPlans();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+
+public sealed class SubscriptionPlanQueryExtension : ObjectTypeExtension<SubscriptionPlanQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<SubscriptionPlanQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetSubscriptionPlans())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Subscriptions;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class SubscriptionQuery(ISubscriptionService subscriptionService)
+{
+    private readonly ISubscriptionService _subscriptionService = subscriptionService;
+
+    public IQueryable<Subscription> GetSubscriptions()
+    {
+        return _subscriptionService.GetSubscriptions();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+
+public sealed class SubscriptionQueryExtension : ObjectTypeExtension<SubscriptionQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<SubscriptionQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetSubscriptions())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.Transactions;
+using System.Transactions;
+
+namespace EkofyApp.Api.GraphQL.Query.Transactions;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class TransactionQuery(ITransactionService transactionService)
+{
+    private readonly ITransactionService _transactionService = transactionService;
+
+    public IQueryable<Transaction> GetTransactions()
+    {
+        return _transactionService.GetTransactions();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.Transactions;
+
+public sealed class TransactionQueryExtension : ObjectTypeExtension<TransactionQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<TransactionQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetTransactions())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQuery.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Application.ServiceInterfaces.UserSubscriptions;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Query.UserSubscriptions;
+
+[ExtendObjectType(typeof(QueryInitialization))]
+[QueryType]
+public sealed class UserSubscriptionQuery(IUserSubscriptionService userSubscriptionService)
+{
+    private readonly IUserSubscriptionService _userSubscriptionService = userSubscriptionService;
+
+    public IQueryable<UserSubscription> GetUserSubscriptions()
+    {
+        return _userSubscriptionService.GetUserSubscriptions();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
@@ -1,0 +1,11 @@
+﻿namespace EkofyApp.Api.GraphQL.Query.UserSubscriptions;
+
+public sealed class UserSubscriptionQueryExtension : ObjectTypeExtension<UserSubscriptionQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<UserSubscriptionQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetUserSubscriptions())
+            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Users/UserQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Users/UserQuery.cs
@@ -12,7 +12,7 @@ public sealed class UserQuery(IUserService userService)
 
     public IQueryable<User> GetUsers()
     {
-        return _userService.GetUsersQueryable();
+        return _userService.GetUsers();
     }
 
     // TODO: Query Object thì dùng Generic T ()

--- a/EkofyApp.Api/GraphQL/Resolver/ListenerResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/ListenerResolver.cs
@@ -1,0 +1,27 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(Listener))]
+public sealed class ListenerResolver
+{
+    public async Task<User?> GetUserAsync(
+        [Parent] Listener listener,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await userByIdDataLoader.LoadAsync(listener.UserId, cancellationToken);
+    }
+
+    // TODO: Cần test kỹ hàm này
+    public async Task<IEnumerable<User>> GetFollowingUserAsync(
+        [Parent] Listener listener,
+        DataLoaderCustomOneToMany<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        IReadOnlyList<IEnumerable<User>?> result = await userByIdDataLoader.LoadAsync(listener.LastFollowing, cancellationToken);
+        // result is IReadOnlyList<IEnumerable<User>?>, flatten and filter nulls
+        return result.Where(x => x != null).SelectMany(x => x!) ?? [];
+    }
+}

--- a/EkofyApp.Application/ServiceInterfaces/Categories/ICategoryService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Categories/ICategoryService.cs
@@ -1,9 +1,11 @@
 ﻿using EkofyApp.Application.Models.Categories;
 using EkofyApp.Domain.EmbeddedDocuments;
+using EkofyApp.Domain.Entities;
 
 namespace EkofyApp.Application.ServiceInterfaces.Categories;
 public interface ICategoryService
 {
     Task CreateCategoryAsync(CreateCategoryRequest createCategoryRequest);
+    IQueryable<Category> GetCategories();
     Task<IEnumerable<string>> GetMoodsFromAudioFeaturesAsync(AudioFeature audioFeature);
 }

--- a/EkofyApp.Application/ServiceInterfaces/Invoices/IInvoiceService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Invoices/IInvoiceService.cs
@@ -1,0 +1,7 @@
+﻿using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Application.ServiceInterfaces.Invoices;
+public interface IInvoiceService
+{
+    IQueryable<Invoice> GetInvoices();
+}

--- a/EkofyApp.Application/ServiceInterfaces/Listeners/IListenerService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Listeners/IListenerService.cs
@@ -1,0 +1,7 @@
+﻿using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Application.ServiceInterfaces.Listeners;
+public interface IListenerService
+{
+    IQueryable<Listener> GetListeners();
+}

--- a/EkofyApp.Application/ServiceInterfaces/MonthlyStreamCounts/IMonthlyStreamCountService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/MonthlyStreamCounts/IMonthlyStreamCountService.cs
@@ -1,0 +1,7 @@
+﻿using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
+public interface IMonthlyStreamCountService
+{
+    IQueryable<MonthlyStreamCount> GetMonthlyStreamCounts();
+}

--- a/EkofyApp.Application/ServiceInterfaces/Playlists/IPlaylistService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Playlists/IPlaylistService.cs
@@ -8,6 +8,6 @@ public interface IPlaylistService
     Task AddToPlaylistAsync(AddToPlaylistRequest addToPlaylistRequest);
     Task CreatePlaylistAsync(CreatePlaylistRequest createPlaylistRequest);
     Task DeletePlaylistAsync(string playlistId);
-    IQueryable<Playlist> GetPlaylistsQueryable();
+    IQueryable<Playlist> GetPlaylists();
     Task RemoveFromPlaylistAsync(AddToPlaylistRequest addToPlaylistRequest);
 }

--- a/EkofyApp.Application/ServiceInterfaces/RoyaltyReports/IRoyaltyReportService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/RoyaltyReports/IRoyaltyReportService.cs
@@ -1,6 +1,9 @@
 ﻿
+using EkofyApp.Domain.Entities;
+
 namespace EkofyApp.Application.ServiceInterfaces.RoyaltyReports;
 public interface IRoyaltyReportService
 {
     Task GenerateMonthlyRoyaltyReportsAsync(int month, int year, CancellationToken ct = default);
+    IQueryable<RoyaltyReport> GetRoyaltyReports();
 }

--- a/EkofyApp.Application/ServiceInterfaces/Subscriptions/ISubscriptionPlanService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Subscriptions/ISubscriptionPlanService.cs
@@ -1,0 +1,7 @@
+﻿using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Application.ServiceInterfaces.Subscriptions;
+public interface ISubscriptionPlanService
+{
+    IQueryable<SubscriptionPlan> GetSubscriptionPlans();
+}

--- a/EkofyApp.Application/ServiceInterfaces/Transactions/ITransactionService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Transactions/ITransactionService.cs
@@ -1,0 +1,7 @@
+﻿using System.Transactions;
+
+namespace EkofyApp.Application.ServiceInterfaces.Transactions;
+public interface ITransactionService
+{
+    IQueryable<Transaction> GetTransactions();
+}

--- a/EkofyApp.Application/ServiceInterfaces/Users/IUserService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Users/IUserService.cs
@@ -7,5 +7,5 @@ public interface IUserService
     Task CreateAdminAsync(CreateAdminRequest createAdminRequest);
     Task CreateModeratorAsync(CreateModeratorRequest createModeratorRequest);
     Task<User> GetUserByIdAsync(string id);
-    IQueryable<User> GetUsersQueryable();
+    IQueryable<User> GetUsers();
 }

--- a/EkofyApp.Domain/Entities/UserSubscription.cs
+++ b/EkofyApp.Domain/Entities/UserSubscription.cs
@@ -1,5 +1,4 @@
 ﻿using EkofyApp.Domain.Base;
-using EkofyApp.Domain.Enums.Subcriptions;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 

--- a/EkofyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
+++ b/EkofyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
@@ -14,13 +14,18 @@ using EkofyApp.Application.ServiceInterfaces.Categories;
 using EkofyApp.Application.ServiceInterfaces.Chat;
 using EkofyApp.Application.ServiceInterfaces.Coupons;
 using EkofyApp.Application.ServiceInterfaces.Entitlements;
+using EkofyApp.Application.ServiceInterfaces.Invoices;
 using EkofyApp.Application.ServiceInterfaces.Jobs;
+using EkofyApp.Application.ServiceInterfaces.Listeners;
+using EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
+using EkofyApp.Application.ServiceInterfaces.Playlists;
 using EkofyApp.Application.ServiceInterfaces.Policies;
 using EkofyApp.Application.ServiceInterfaces.Recordings;
 using EkofyApp.Application.ServiceInterfaces.RequestHubs;
 using EkofyApp.Application.ServiceInterfaces.RoyaltyReports;
 using EkofyApp.Application.ServiceInterfaces.Subscriptions;
 using EkofyApp.Application.ServiceInterfaces.Tracks;
+using EkofyApp.Application.ServiceInterfaces.Transactions;
 using EkofyApp.Application.ServiceInterfaces.Users;
 using EkofyApp.Application.ServiceInterfaces.UserSubscriptions;
 using EkofyApp.Application.ServiceInterfaces.Works;
@@ -50,13 +55,18 @@ using EkofyApp.Infrastructure.Services.Categories;
 using EkofyApp.Infrastructure.Services.Chat;
 using EkofyApp.Infrastructure.Services.Coupons;
 using EkofyApp.Infrastructure.Services.Entitlements;
+using EkofyApp.Infrastructure.Services.Invoices;
 using EkofyApp.Infrastructure.Services.Jobs;
+using EkofyApp.Infrastructure.Services.Listeners;
+using EkofyApp.Infrastructure.Services.MonthlyStreamCounts;
+using EkofyApp.Infrastructure.Services.Playlists;
 using EkofyApp.Infrastructure.Services.Policies;
 using EkofyApp.Infrastructure.Services.Recordings;
 using EkofyApp.Infrastructure.Services.RequestHubs;
 using EkofyApp.Infrastructure.Services.RoyaltyReports;
 using EkofyApp.Infrastructure.Services.Subscriptions;
 using EkofyApp.Infrastructure.Services.Tracks;
+using EkofyApp.Infrastructure.Services.Transactions;
 using EkofyApp.Infrastructure.Services.Users;
 using EkofyApp.Infrastructure.Services.UserSubscriptions;
 using EkofyApp.Infrastructure.Services.Works;
@@ -343,7 +353,9 @@ public static class DependencyInjection
         // Business Services
         services.AddScoped<ITrackService, TrackService>();
         services.AddScoped<ICategoryService, CategoryService>();
+        services.AddScoped<IPlaylistService, PlaylistService>();
         services.AddScoped<IArtistService, ArtistService>();
+        services.AddScoped<IListenerService, ListenerService>();
         services.AddScoped<IAudioAnalysisService, AudioFeatureService>();
         services.AddScoped<IAudioFingerprintService, AudioFingerprintService>();
         services.AddScoped<IJsonWebToken, JsonWebToken>();
@@ -362,6 +374,10 @@ public static class DependencyInjection
         services.AddScoped<IRoyaltyReportService, RoyaltyReportService>();
         services.AddScoped<IRoyaltyPolicyService, RoyaltyPolicyService>();
         services.AddScoped<ILegalPolicyService, LegalPolicyService>();
+        services.AddScoped<IInvoiceService, Services.Invoices.InvoiceService>();
+        services.AddScoped<ISubscriptionPlanService, SubscriptionPlanService>();
+        services.AddScoped<IMonthlyStreamCountService, MonthlyStreamCountService>();
+        services.AddScoped<ITransactionService, TransactionService>();
         //services.AddScoped<IChatService, ChatService>();
 
         // GraphQL Services

--- a/EkofyApp.Infrastructure/Services/Categories/CategoryService.cs
+++ b/EkofyApp.Infrastructure/Services/Categories/CategoryService.cs
@@ -12,7 +12,7 @@ public class CategoryService(IUnitOfWork unitOfWork) : ICategoryService
 {
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
 
-    public IQueryable<Category> GetCategoriesQueryable()
+    public IQueryable<Category> GetCategories()
     {
         return _unitOfWork.GetCollection<Category>().AsQueryable();
     }

--- a/EkofyApp.Infrastructure/Services/Invoices/InvoiceService.cs
+++ b/EkofyApp.Infrastructure/Services/Invoices/InvoiceService.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces;
+using EkofyApp.Application.ServiceInterfaces.Invoices;
+using EkofyApp.Domain.Entities;
+using MongoDB.Driver;
+
+namespace EkofyApp.Infrastructure.Services.Invoices;
+public sealed class InvoiceService(IUnitOfWork unitOfWork) : IInvoiceService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public IQueryable<Invoice> GetInvoices()
+    {
+        return _unitOfWork.GetCollection<Invoice>().AsQueryable();
+    }
+}

--- a/EkofyApp.Infrastructure/Services/Listeners/ListenerService.cs
+++ b/EkofyApp.Infrastructure/Services/Listeners/ListenerService.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces;
+using EkofyApp.Application.ServiceInterfaces.Listeners;
+using EkofyApp.Domain.Entities;
+using MongoDB.Driver;
+
+namespace EkofyApp.Infrastructure.Services.Listeners;
+public sealed class ListenerService(IUnitOfWork unitOfWork) : IListenerService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public IQueryable<Listener> GetListeners()
+    {
+        return _unitOfWork.GetCollection<Listener>().AsQueryable();
+    }
+}

--- a/EkofyApp.Infrastructure/Services/MonthlyStreamCounts/MonthlyStreamCountService.cs
+++ b/EkofyApp.Infrastructure/Services/MonthlyStreamCounts/MonthlyStreamCountService.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces;
+using EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
+using EkofyApp.Domain.Entities;
+using MongoDB.Driver;
+
+namespace EkofyApp.Infrastructure.Services.MonthlyStreamCounts;
+public sealed class MonthlyStreamCountService(IUnitOfWork unitOfWork) : IMonthlyStreamCountService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public IQueryable<MonthlyStreamCount> GetMonthlyStreamCounts()
+    {
+        return _unitOfWork.GetCollection<MonthlyStreamCount>().AsQueryable();
+    }
+}

--- a/EkofyApp.Infrastructure/Services/Playlists/PlaylistService.cs
+++ b/EkofyApp.Infrastructure/Services/Playlists/PlaylistService.cs
@@ -14,7 +14,7 @@ public sealed class PlaylistService(IUnitOfWork unitOfWork, IHttpContextAccessor
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
     private readonly IHttpContextAccessor _httpContextAccessor = httpContextAccessor;
 
-    public IQueryable<Playlist> GetPlaylistsQueryable()
+    public IQueryable<Playlist> GetPlaylists()
     {
         return _unitOfWork.GetCollection<Playlist>().AsQueryable();
     }

--- a/EkofyApp.Infrastructure/Services/RoyaltyReports/RoyaltyReportService.cs
+++ b/EkofyApp.Infrastructure/Services/RoyaltyReports/RoyaltyReportService.cs
@@ -15,6 +15,11 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
     private readonly IRedisCacheService _redisCacheService = redisCacheService;
 
+    public IQueryable<RoyaltyReport> GetRoyaltyReports()
+    {
+        return _unitOfWork.GetCollection<RoyaltyReport>().AsQueryable();
+    }
+
     private async Task<Dictionary<string, string?>> GetRoyaltyPolicyValuesAsync(string key, params string[] fields)
     {
         var tasks = fields.Select(field =>

--- a/EkofyApp.Infrastructure/Services/Subscriptions/SubscriptionPlanService.cs
+++ b/EkofyApp.Infrastructure/Services/Subscriptions/SubscriptionPlanService.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces;
+using EkofyApp.Application.ServiceInterfaces.Subscriptions;
+using EkofyApp.Domain.Entities;
+using MongoDB.Driver;
+
+namespace EkofyApp.Infrastructure.Services.Subscriptions;
+public sealed class SubscriptionPlanService(IUnitOfWork unitOfWork) : ISubscriptionPlanService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public IQueryable<SubscriptionPlan> GetSubscriptionPlans()
+    {
+        return _unitOfWork.GetCollection<SubscriptionPlan>().AsQueryable();
+    }
+}

--- a/EkofyApp.Infrastructure/Services/Subscriptions/SubscriptionService.cs
+++ b/EkofyApp.Infrastructure/Services/Subscriptions/SubscriptionService.cs
@@ -7,7 +7,6 @@ using EkofyApp.Domain.Entities;
 using EkofyApp.Domain.Enums;
 using EkofyApp.Domain.Enums.Subcriptions;
 using EkofyApp.Domain.Exceptions;
-using HotChocolate.Execution.Processing;
 using Microsoft.Extensions.Logging;
 using MongoDB.Bson;
 using MongoDB.Driver;

--- a/EkofyApp.Infrastructure/Services/Transactions/TransactionService.cs
+++ b/EkofyApp.Infrastructure/Services/Transactions/TransactionService.cs
@@ -1,0 +1,15 @@
+﻿using EkofyApp.Application.ServiceInterfaces;
+using EkofyApp.Application.ServiceInterfaces.Transactions;
+using MongoDB.Driver;
+using System.Transactions;
+
+namespace EkofyApp.Infrastructure.Services.Transactions;
+public sealed class TransactionService(IUnitOfWork unitOfWork) : ITransactionService
+{
+    private readonly IUnitOfWork _unitOfWork = unitOfWork;
+
+    public IQueryable<Transaction> GetTransactions()
+    {
+        return _unitOfWork.GetCollection<Transaction>().AsQueryable();
+    }
+}

--- a/EkofyApp.Infrastructure/Services/Users/UserService.cs
+++ b/EkofyApp.Infrastructure/Services/Users/UserService.cs
@@ -12,7 +12,7 @@ public sealed class UserService(IUnitOfWork unitOfWork) : IUserService
 {
     private readonly IUnitOfWork _unitOfWork = unitOfWork;
 
-    public IQueryable<User> GetUsersQueryable()
+    public IQueryable<User> GetUsers()
     {
         return _unitOfWork.GetCollection<User>().AsQueryable();
     }


### PR DESCRIPTION
Introduces GraphQL query and extension classes for categories, entitlements, invoices, listeners, monthly stream counts, playlists, policies, royalty reports, subscriptions, transactions, and user subscriptions. Adds corresponding service interfaces and implementations for these entities, updates dependency injection to register new services, and refactors existing service and query method names for consistency. Removes entitlement query from mutation and adjusts authorization roles for new queries.