### PR TITLE
Refactor GraphQL query authorization and add resolvers

### DIFF
--- a/EkofyApp.Api/GraphQL/Query/Artists/ArtistQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Artists/ArtistQueryExtension.cs
@@ -1,4 +1,6 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Artists;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Artists;
 
 public sealed class ArtistQueryExtension : ObjectTypeExtension<ArtistQuery>
 {
@@ -10,6 +12,7 @@ public sealed class ArtistQueryExtension : ObjectTypeExtension<ArtistQuery>
         // descriptor.Field(x => x.GetAllArtists()).Description("Returns all artists.");
 
         descriptor.Field(x => x.GetArtists())
+            .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
             .UseSorting();

--- a/EkofyApp.Api/GraphQL/Query/Categories/CategoryQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Categories/CategoryQueryExtension.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Categories;
+
+public sealed class CategoryQueryExtension : ObjectTypeExtension<CategoryQuery>
+{
+    protected override void Configure(IObjectTypeDescriptor<CategoryQuery> descriptor)
+    {
+        descriptor.Field(x => x.GetCategories())
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
+        //.AllowAnonymous();
+    }
+}

--- a/EkofyApp.Api/GraphQL/Query/Coupons/CouponQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Coupons/CouponQueryExtension.cs
@@ -1,4 +1,6 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Coupons;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Coupons;
 
 public sealed class CouponQueryExtension : ObjectTypeExtension<CouponQuery>
 {
@@ -6,7 +8,7 @@ public sealed class CouponQueryExtension : ObjectTypeExtension<CouponQuery>
     {
         // Configure the CouponQuery type here if needed
         descriptor.Field(x => x.GetAllCoupons())
-            .Authorize(roles: "Admin")
+            .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
             .UseSorting();

--- a/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Entitlements;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Entitlements;
 
 public sealed class EntitlementQueryExtension : ObjectTypeExtension<EntitlementQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<EntitlementQuery> descriptor)
     {
         descriptor.Field(x => x.GetEntitlements())
-            .Authorize(roles: "Admin");
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Invoices;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Invoices;
 
 public sealed class InvoiceQueryExtension : ObjectTypeExtension<InvoiceQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<InvoiceQuery> descriptor)
     {
         descriptor.Field(x => x.GetInvoices())
-            .Authorize(roles: ["Listener", "Artist", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Listeners;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Listeners;
 
 public sealed class ListenerQueryExtension : ObjectTypeExtension<ListenerQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<ListenerQuery> descriptor)
     {
         descriptor.Field(x => x.GetListeners())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.MonthlyStreamCounts;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.MonthlyStreamCounts;
 
 public sealed class MonthlyStreamCountQueryExtension : ObjectTypeExtension<MonthlyStreamCountQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<MonthlyStreamCountQuery> descriptor)
     {
         descriptor.Field(x => x.GetMonthlyStreamCounts())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Playlists;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Playlists;
 
 public sealed class PlaylistQueryExtension : ObjectTypeExtension<PlaylistQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<PlaylistQuery> descriptor)
     {
         descriptor.Field(x => x.GetPlaylists())
-            .Authorize(roles: ["Listener", "Artist"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Policies;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Policies;
 
 public sealed class LegalPolicyQueryExtension : ObjectTypeExtension<LegalPolicyQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<LegalPolicyQuery> descriptor)
     {
         descriptor.Field(x => x.GetLegalPolicies())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Policies;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Policies;
 
 public sealed class RoyaltyPolicyQueryExtension : ObjectTypeExtension<RoyaltyPolicyQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<RoyaltyPolicyQuery> descriptor)
     {
         descriptor.Field(x => x.GetRoyaltyPolicies())
-            .Authorize(roles: "Admin");
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Recordings/RecordingQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Recordings/RecordingQueryExtension.cs
@@ -1,13 +1,21 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Recordings;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Recordings;
 
 public sealed class RecordingQueryExtension : ObjectTypeExtension<RecordingQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<RecordingQuery> descriptor)
     {
         descriptor.Field(x => x.GetRecordingsQueryable())
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
 
         descriptor.Field(x => x.GetMetadataRecordingUploadRequestAsync(default!))
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.RoyalReports;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.RoyalReports;
 
 public sealed class RoyaltyReportQueryExtension : ObjectTypeExtension<RoyaltyReportQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<RoyaltyReportQuery> descriptor)
     {
         descriptor.Field(x => x.GetRoyaltyReports())
-            .Authorize(roles: ["Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
 
 public sealed class SubscriptionPlanQueryExtension : ObjectTypeExtension<SubscriptionPlanQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<SubscriptionPlanQuery> descriptor)
     {
         descriptor.Field(x => x.GetSubscriptionPlans())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
 
 public sealed class SubscriptionQueryExtension : ObjectTypeExtension<SubscriptionQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<SubscriptionQuery> descriptor)
     {
         descriptor.Field(x => x.GetSubscriptions())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Tracks/TrackQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Tracks/TrackQueryExtension.cs
@@ -1,22 +1,33 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Tracks;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Tracks;
 
 public class TrackQueryExtension : ObjectTypeExtension<TrackQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<TrackQuery> descriptor)
     {
         descriptor.Field(x => x.GetTracks())
+            .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting()
-            .Authorize(roles: ["Listener", "Artist"]);
+            .UseSorting();
 
         descriptor.Field(x => x.GetPendingTrackUploadRequestsAsync())
-                .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.ModeratorRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
 
         descriptor.Field(x => x.GetMetadataTrackUploadRequestAsync(default!))
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.ModeratorRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
 
         descriptor.Field(x => x.GetOriginalFileTrackUploadRequest(default!))
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.ModeratorRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Transactions;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Transactions;
 
 public sealed class TransactionQueryExtension : ObjectTypeExtension<TransactionQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<TransactionQuery> descriptor)
     {
         descriptor.Field(x => x.GetTransactions())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
@@ -1,11 +1,16 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.UserSubscriptions;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.UserSubscriptions;
 
 public sealed class UserSubscriptionQueryExtension : ObjectTypeExtension<UserSubscriptionQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<UserSubscriptionQuery> descriptor)
     {
         descriptor.Field(x => x.GetUserSubscriptions())
-            .Authorize(roles: ["Listener", "Artist", "Moderator", "Admin"]);
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Users/UserQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Users/UserQueryExtension.cs
@@ -1,5 +1,6 @@
 ﻿using EkofyApp.Domain.Entities;
 using EkofyApp.Domain.Enums.Users;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Users;
 
@@ -13,11 +14,15 @@ public class UserQueryExtension : ObjectTypeExtension<UserQuery>
             //    options.ProviderName = PagingProviderNames.Cursor; // CURSOR PAGING
             //    options.IncludeTotalCount = true;
             //})
+            .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
             .UseSorting();
 
         descriptor.Field(x => x.GetUserByIdAsync(default!))
-        .Authorize(roles: "Admin");
+            .Authorize(roles: HelperRoleBase.FullRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Works/WorkQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Works/WorkQueryExtension.cs
@@ -1,14 +1,22 @@
-﻿namespace EkofyApp.Api.GraphQL.Query.Works;
+﻿using EkofyApp.Domain.Utils;
+
+namespace EkofyApp.Api.GraphQL.Query.Works;
 
 public sealed class WorkQueryExtension : ObjectTypeExtension<WorkQuery>
 {
     protected override void Configure(IObjectTypeDescriptor<WorkQuery> descriptor)
     {
         descriptor.Field(x => x.GetWorksQueryable())
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.ModeratorRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
 
         descriptor.Field(x => x.GetMetadataWorkUploadRequestAsync(default!))
-            .Authorize(roles: "Moderator");
+            .Authorize(roles: HelperRoleBase.ModeratorRoles)
+            .UseProjection()
+            .UseFiltering()
+            .UseSorting();
 
         // TODO: Artist cũng nên xem được các work của chính mình
     }

--- a/EkofyApp.Api/GraphQL/Resolver/InvoiceResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/InvoiceResolver.cs
@@ -1,0 +1,24 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(Invoice))]
+public sealed class InvoiceResolver
+{
+    public async Task<User?> GetUserAsync(
+        [Parent] Invoice invoice,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await userByIdDataLoader.LoadAsync(invoice.UserId, cancellationToken);
+    }
+
+    public async Task<Transaction?> GetTransactionAsync(
+        [Parent] Invoice invoice,
+        DataLoaderCustomOneToOne<Transaction> transactionByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await transactionByIdDataLoader.LoadAsync(invoice.TransactionId, cancellationToken);
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/MonthlyStreamCountResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/MonthlyStreamCountResolver.cs
@@ -1,0 +1,42 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(MonthlyStreamCount))]
+public sealed class MonthlyStreamCountResolver
+{
+    public async Task<Track?> GetTrackAsync(
+        [Parent] MonthlyStreamCount monthlyStreamCount,
+        DataLoaderCustomOneToOne<Track> trackByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await trackByIdDataLoader.LoadAsync(monthlyStreamCount.TrackId, cancellationToken);
+    }
+
+    public async Task<Recording?> GetRecordingAsync(
+        [Parent] MonthlyStreamCount monthlyStreamCount,
+        DataLoaderCustomOneToOne<Recording> recordingByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        if (monthlyStreamCount.RecordingId == null)
+        {
+            return null;
+        }
+
+        return await recordingByIdDataLoader.LoadAsync(monthlyStreamCount.RecordingId, cancellationToken);
+    }
+
+    public async Task<Work?> GetWorkAsync(
+        [Parent] MonthlyStreamCount monthlyStreamCount,
+        DataLoaderCustomOneToOne<Work> workByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        if (monthlyStreamCount.WorkId == null)
+        {
+            return null;
+        }
+
+        return await workByIdDataLoader.LoadAsync(monthlyStreamCount.WorkId, cancellationToken);
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/PlaylistResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/PlaylistResolver.cs
@@ -1,0 +1,25 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(Playlist))]
+public sealed class PlaylistResolver
+{
+    public async Task<User?> GetUserAsync(
+        [Parent] Playlist playlist,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await userByIdDataLoader.LoadAsync(playlist.UserId, cancellationToken);
+    }
+
+    public async Task<IEnumerable<Track?>> GetTracksAsync(
+        [Parent] Playlist playlist,
+        DataLoaderCustomOneToOne<Track> trackByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        List<string> trackIds = playlist.TracksInfo.Select(t => t.TrackId).ToList();
+        return await trackByIdDataLoader.LoadAsync(trackIds, cancellationToken) ?? [];
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/RecordingResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/RecordingResolver.cs
@@ -1,0 +1,24 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+[ExtendObjectType(typeof(Recording))]
+public sealed class RecordingResolver
+{
+    public async Task<Track?> GetTrackAsync(
+        [Parent] Recording recording,
+        DataLoaderCustomOneToOne<Track> trackByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await trackByIdDataLoader.LoadAsync(recording.TrackId, cancellationToken);
+    }
+
+    public async Task<IEnumerable<User?>> GetUsersAsync(
+        [Parent] Recording recording,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        List<string> userIds = recording.RecordingSplits.Select(rs => rs.UserId).ToList();
+        return await userByIdDataLoader.LoadAsync(userIds, cancellationToken) ?? [];
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/RoyaltyReportResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/RoyaltyReportResolver.cs
@@ -1,0 +1,25 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(RoyaltyReport))]
+public sealed class RoyaltyReportResolver
+{
+    public async Task<Track?> GetTrackAsync(
+        [Parent] RoyaltyReport royaltyReport,
+        DataLoaderCustomOneToOne<Track> trackByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await trackByIdDataLoader.LoadAsync(royaltyReport.TrackId, cancellationToken);
+    }
+
+    public async Task<IEnumerable<User?>> GetUsersAsync(
+        [Parent] RoyaltyReport royaltyReport,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        List<string> userIds = royaltyReport.RoyaltySplits.Select(rs => rs.UserId).ToList();
+        return await userByIdDataLoader.LoadAsync(userIds, cancellationToken) ?? [];
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/SubscriptionPlanResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/SubscriptionPlanResolver.cs
@@ -1,0 +1,16 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(SubscriptionPlan))]
+public sealed class SubscriptionPlanResolver
+{
+    public async Task<Subscription?> GetSubscriptionAsync(
+        [Parent] SubscriptionPlan subscriptionPlan,
+        DataLoaderCustomOneToOne<Subscription> subscriptionByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await subscriptionByIdDataLoader.LoadAsync(subscriptionPlan.SubscriptionId, cancellationToken);
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/TracksResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/TracksResolver.cs
@@ -1,5 +1,4 @@
 ﻿using EkofyApp.Api.GraphQL.DataLoader;
-using EkofyApp.Api.GraphQL.DataLoader.Artists;
 using EkofyApp.Domain.Entities;
 
 namespace EkofyApp.Api.GraphQL.Resolver;

--- a/EkofyApp.Api/GraphQL/Resolver/TransactionResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/TransactionResolver.cs
@@ -1,0 +1,17 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(Transaction))]
+public sealed class TransactionResolver
+{
+    public async Task<User?> GetUserAsync(
+        [Parent] Transaction transaction,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(userByIdDataLoader);
+        return await userByIdDataLoader.LoadAsync(transaction.UserId, cancellationToken);
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/UserSubscriptionResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/UserSubscriptionResolver.cs
@@ -1,0 +1,24 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(UserSubscription))]
+public sealed class UserSubscriptionResolver
+{
+    public async Task<User?> GetUserAsync(
+        [Parent] UserSubscription userSubscription,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await userByIdDataLoader.LoadAsync(userSubscription.UserId, cancellationToken);
+    }
+
+    public async Task<Subscription?> GetSubscriptionAsync(
+        [Parent] UserSubscription userSubscription,
+        DataLoaderCustomOneToOne<Subscription> subscriptionByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await subscriptionByIdDataLoader.LoadAsync(userSubscription.SubscriptionId, cancellationToken);
+    }
+}

--- a/EkofyApp.Api/GraphQL/Resolver/WorkResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/WorkResolver.cs
@@ -1,0 +1,25 @@
+﻿using EkofyApp.Api.GraphQL.DataLoader;
+using EkofyApp.Domain.Entities;
+
+namespace EkofyApp.Api.GraphQL.Resolver;
+
+[ExtendObjectType(typeof(Work))]
+public sealed class WorkResolver
+{
+    public async Task<Track?> GetTrackAsync(
+        [Parent] Work work,
+        DataLoaderCustomOneToOne<Track> trackByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        return await trackByIdDataLoader.LoadAsync(work.TrackId, cancellationToken);
+    }
+
+    public async Task<IEnumerable<User?>> GetUsersAsync(
+        [Parent] Work work,
+        DataLoaderCustomOneToOne<User> userByIdDataLoader,
+        CancellationToken cancellationToken)
+    {
+        List<string> userIds = work.WorkSplits.Select(ws => ws.UserId).ToList();
+        return await userByIdDataLoader.LoadAsync(userIds, cancellationToken) ?? [];
+    }
+}

--- a/EkofyApp.Domain/EmbeddedDocuments/SubscriptionPlanPrice.cs
+++ b/EkofyApp.Domain/EmbeddedDocuments/SubscriptionPlanPrice.cs
@@ -1,6 +1,4 @@
 ﻿using EkofyApp.Domain.Enums;
-using MongoDB.Bson;
-using MongoDB.Bson.Serialization.Attributes;
 
 namespace EkofyApp.Domain.EmbeddedDocuments;
 public sealed class SubscriptionPlanPrice

--- a/EkofyApp.Domain/Utils/HelperRoleBase.cs
+++ b/EkofyApp.Domain/Utils/HelperRoleBase.cs
@@ -1,0 +1,59 @@
+﻿using EkofyApp.Domain.Enums.Users;
+
+namespace EkofyApp.Domain.Utils;
+public static class HelperRoleBase
+{
+    private static readonly string listenerRole = UserRole.Listener.ToString();
+    private static readonly string artistRole = UserRole.Artist.ToString();
+    private static readonly string moderatorRole = UserRole.Moderator.ToString();
+    private static readonly string adminRole = UserRole.Admin.ToString();
+
+    #region 4 roles
+    private static readonly string[] fullRoles = [listenerRole, artistRole, moderatorRole, adminRole];
+    #endregion
+
+    #region 3 roles
+    private static readonly string[] listenerArtistModeratorRoles = [listenerRole, artistRole, moderatorRole];
+    private static readonly string[] listenerArtistAdminRoles = [listenerRole, artistRole, adminRole];
+    private static readonly string[] listenerModeratorAdminRoles = [listenerRole, moderatorRole, adminRole];
+    private static readonly string[] artistModeratorAdminRoles = [artistRole, moderatorRole, adminRole];
+    #endregion
+
+    #region 2 roles
+    private static readonly string[] listenerArtistRoles = [listenerRole, artistRole];
+    private static readonly string[] listenerModeratorRoles = [listenerRole, moderatorRole];
+    private static readonly string[] listenerAdminRoles = [listenerRole, adminRole];
+    private static readonly string[] artistModeratorRoles = [artistRole, moderatorRole];
+    private static readonly string[] artistAdminRoles = [artistRole, adminRole];
+    private static readonly string[] moderatorAdminRoles = [moderatorRole, adminRole];
+    #endregion
+
+    #region 1 role
+    private static readonly string[] listenerRoles = [listenerRole];
+    private static readonly string[] artistRoles = [artistRole];
+    private static readonly string[] moderatorRoles = [moderatorRole];
+    private static readonly string[] adminRoles = [adminRole];
+    #endregion
+
+    public static string[] FullRoles => fullRoles;
+
+    // 3 roles
+    public static string[] ListenerArtistModeratorRoles => listenerArtistModeratorRoles;
+    public static string[] ListenerArtistAdminRoles => listenerArtistAdminRoles;
+    public static string[] ListenerModeratorAdminRoles => listenerModeratorAdminRoles;
+    public static string[] ArtistModeratorAdminRoles => artistModeratorAdminRoles;
+
+    // 2 roles
+    public static string[] ListenerArtistRoles => listenerArtistRoles;
+    public static string[] ListenerModeratorRoles => listenerModeratorRoles;
+    public static string[] ListenerAdminRoles => listenerAdminRoles;
+    public static string[] ArtistModeratorRoles => artistModeratorRoles;
+    public static string[] ArtistAdminRoles => artistAdminRoles;
+    public static string[] ModeratorAdminRoles => moderatorAdminRoles;
+
+    // 1 role
+    public static string[] ListenerRoles => listenerRoles;
+    public static string[] ArtistRoles => artistRoles;
+    public static string[] ModeratorRoles => moderatorRoles;
+    public static string[] AdminRoles => adminRoles;
+}


### PR DESCRIPTION
Replaced hardcoded role strings in GraphQL query extensions with HelperRoleBase constants for consistent authorization. Added new resolver classes for Invoice, MonthlyStreamCount, Playlist, Recording, RoyaltyReport, SubscriptionPlan, Transaction, UserSubscription, and Work entities to support related data loading. Introduced HelperRoleBase utility for role management. Cleaned up unused MongoDB usings in SubscriptionPlanPrice.