### PR TITLE
Refactor MonthlyStreamCount to remove RecordingId and WorkId

### DIFF
--- a/EkofyApp.Api/GraphQL/Resolver/MonthlyStreamCountResolver.cs
+++ b/EkofyApp.Api/GraphQL/Resolver/MonthlyStreamCountResolver.cs
@@ -13,30 +13,4 @@ public sealed class MonthlyStreamCountResolver
     {
         return await trackByIdDataLoader.LoadAsync(monthlyStreamCount.TrackId, cancellationToken);
     }
-
-    public async Task<Recording?> GetRecordingAsync(
-        [Parent] MonthlyStreamCount monthlyStreamCount,
-        DataLoaderCustomOneToOne<Recording> recordingByIdDataLoader,
-        CancellationToken cancellationToken)
-    {
-        if (monthlyStreamCount.RecordingId == null)
-        {
-            return null;
-        }
-
-        return await recordingByIdDataLoader.LoadAsync(monthlyStreamCount.RecordingId, cancellationToken);
-    }
-
-    public async Task<Work?> GetWorkAsync(
-        [Parent] MonthlyStreamCount monthlyStreamCount,
-        DataLoaderCustomOneToOne<Work> workByIdDataLoader,
-        CancellationToken cancellationToken)
-    {
-        if (monthlyStreamCount.WorkId == null)
-        {
-            return null;
-        }
-
-        return await workByIdDataLoader.LoadAsync(monthlyStreamCount.WorkId, cancellationToken);
-    }
 }

--- a/EkofyApp.Application/Models/Projections/MonthlyStreamCountProjection.cs
+++ b/EkofyApp.Application/Models/Projections/MonthlyStreamCountProjection.cs
@@ -1,5 +1,4 @@
-﻿using EkofyApp.Domain.Entities;
-using EkofyApp.Domain.Enums;
+﻿using EkofyApp.Domain.Enums;
 using EkofyApp.Domain.Utils;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
@@ -15,18 +14,10 @@ public sealed class MonthlyStreamCountProjection
     [BsonRepresentation(BsonType.ObjectId)]
     public string TrackId { get; set; } = null!;
 
-    [BsonRepresentation(BsonType.ObjectId)]
-    public string? RecordingId { get; set; }
-
-    [BsonRepresentation(BsonType.ObjectId)]
-    public string? WorkId { get; set; }
-
     public int Month { get; set; } // ví dụ: 9
     public int Year { get; set; }  // ví dụ: 2025
 
     public long StreamCount { get; set; } = 0; // Tổng số lượt stream
-
-    public AggregationLevel Level { get; set; } // Mức độ tổng hợp: Track, RecordingProjection, WorkProjection
 
     public DateTimeOffset CreatedAt { get; set; } = HelperMethod.GetUtcPlus7TimeOffset(); // Thời gian tạo bản ghi
     public DateTimeOffset? ProcessedAt { get; set; } // Thời gian xử lý cuối cùng

--- a/EkofyApp.Application/ServiceInterfaces/MonthlyStreamCounts/IMonthlyStreamCountService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/MonthlyStreamCounts/IMonthlyStreamCountService.cs
@@ -4,4 +4,5 @@ namespace EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
 public interface IMonthlyStreamCountService
 {
     IQueryable<MonthlyStreamCount> GetMonthlyStreamCounts();
+    Task UpsertMonthlyStreamCountAsync(string trackId, long streamCount, int month, int year, CancellationToken cancellationToken = default);
 }

--- a/EkofyApp.Domain/Entities/MonthlyStreamCount.cs
+++ b/EkofyApp.Domain/Entities/MonthlyStreamCount.cs
@@ -1,5 +1,4 @@
-﻿using EkofyApp.Domain.Enums;
-using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Utils;
 using MongoDB.Bson;
 using MongoDB.Bson.Serialization.Attributes;
 
@@ -13,18 +12,10 @@ public sealed class MonthlyStreamCount : IEntityCustom
     [BsonRepresentation(BsonType.ObjectId)]
     public string TrackId { get; set; } = null!;
 
-    [BsonRepresentation(BsonType.ObjectId)]
-    public string? RecordingId { get; set; }
-
-    [BsonRepresentation(BsonType.ObjectId)]
-    public string? WorkId { get; set; }
-
     public int Month { get; set; } // ví dụ: 9
     public int Year { get; set; }  // ví dụ: 2025
 
     public long StreamCount { get; set; } = 0; // Tổng số lượt stream
-
-    public AggregationLevel Level { get; set; } // Mức độ tổng hợp: Track, Recording, Work
 
     public DateTimeOffset CreatedAt { get; set; } = HelperMethod.GetUtcPlus7TimeOffset(); // Thời gian tạo bản ghi
     public DateTimeOffset? ProcessedAt { get; set; } // Thời gian xử lý cuối cùng

--- a/EkofyApp.Infrastructure/Services/MonthlyStreamCounts/MonthlyStreamCountService.cs
+++ b/EkofyApp.Infrastructure/Services/MonthlyStreamCounts/MonthlyStreamCountService.cs
@@ -1,6 +1,7 @@
 ﻿using EkofyApp.Application.ServiceInterfaces;
 using EkofyApp.Application.ServiceInterfaces.MonthlyStreamCounts;
 using EkofyApp.Domain.Entities;
+using MongoDB.Bson;
 using MongoDB.Driver;
 
 namespace EkofyApp.Infrastructure.Services.MonthlyStreamCounts;
@@ -11,5 +12,24 @@ public sealed class MonthlyStreamCountService(IUnitOfWork unitOfWork) : IMonthly
     public IQueryable<MonthlyStreamCount> GetMonthlyStreamCounts()
     {
         return _unitOfWork.GetCollection<MonthlyStreamCount>().AsQueryable();
+    }
+
+    public async Task UpsertMonthlyStreamCountAsync(string trackId, long streamCount, int month, int year, CancellationToken cancellationToken = default)
+    {
+        FilterDefinition<MonthlyStreamCount> filter = Builders<MonthlyStreamCount>.Filter.Where(m => m.TrackId == trackId && m.Month == month && m.Year == year && m.ProcessedAt == null);
+
+        UpdateDefinition<MonthlyStreamCount> updateDefinition = Builders<MonthlyStreamCount>.Update
+            .Inc(m => m.StreamCount, streamCount)
+            .SetOnInsert(m => m.Id, ObjectId.GenerateNewId().ToString())
+            .SetOnInsert(m => m.TrackId, trackId)
+            .SetOnInsert(m => m.Month, month)
+            .SetOnInsert(m => m.Year, year);
+
+        await _unitOfWork.GetCollection<MonthlyStreamCount>().UpdateOneAsync(
+            filter,
+            updateDefinition,
+            new UpdateOptions { IsUpsert = true },
+            cancellationToken: cancellationToken
+        );
     }
 }

--- a/EkofyApp.Infrastructure/Services/Recordings/RecordingService.cs
+++ b/EkofyApp.Infrastructure/Services/Recordings/RecordingService.cs
@@ -97,23 +97,6 @@ public sealed class RecordingService(IUnitOfWork unitOfWork) : IRecordingService
             };
 
             await _unitOfWork.GetCollection<Recording>().InsertOneAsync(session, newRecording, cancellationToken: cancellationToken);
-
-            // Cập nhật lại MonthlyStreamCount để tham chiếu đến Recording mới
-            UpdateDefinition<MonthlyStreamCount> updateStreamCount = Builders<MonthlyStreamCount>.Update.Set(m => m.RecordingId, newRecording.Id);
-            UpdateResult updateResult = await _unitOfWork.GetCollection<MonthlyStreamCount>().UpdateOneAsync(session,
-                m => m.TrackId == trackId && m.RecordingId == currentRecording.Id && m.ProcessedAt == null,
-                updateStreamCount,
-                cancellationToken: cancellationToken);
-            if (updateResult.MatchedCount == 0)
-            {
-                throw new NotFoundCustomException("Not found monthly stream count with given conditions");
-            }
-
-            if (updateResult.ModifiedCount == 0)
-            {
-                throw new ConflictCustomException("Failed to update MonthlyStreamCount records with the new RecordingId.");
-            }
         });
     }
-
 }

--- a/EkofyApp.Infrastructure/Services/RoyaltyReports/RoyaltyReportService.cs
+++ b/EkofyApp.Infrastructure/Services/RoyaltyReports/RoyaltyReportService.cs
@@ -52,25 +52,23 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
             decimal workRoyaltyPercentage = Convert.ToDecimal(royaltyPolicyValues["work_percentage"]);
 
             ProjectionDefinition<MonthlyStreamCountProjection> projectionDefinition = Builders<MonthlyStreamCountProjection>.Projection
-                    .Exclude(x => x.CreatedAt)
-                    .Exclude(x => x.Level);
+                    .Exclude(x => x.CreatedAt);
 
             // Lấy toàn bộ thống kê theo tháng
             List<MonthlyStreamCountProjection> monthlyStreamCountProjections = await _unitOfWork.GetCollection<MonthlyStreamCount>()
-                .Aggregate()
-                .Match(x => x.Month == month && x.Year == year && x.ProcessedAt == null)
-                .Lookup<MonthlyStreamCount, Recording, MonthlyStreamCountProjection>(
-                    _unitOfWork.GetCollection<Recording>(),
-                    x => x.RecordingId,
-                    x => x.Id,
-                    x => x.RecordingProjection)
-                .Lookup<MonthlyStreamCountProjection, Work, MonthlyStreamCountProjection>(
-                    _unitOfWork.GetCollection<Work>(),
-                    x => x.WorkId,
-                    x => x.Id,
-                    x => x.WorkProjection)
-                .Project<MonthlyStreamCountProjection>(projectionDefinition)
-                .ToListAsync(ct);
+                    .Aggregate()
+                    .Match(x => x.Month == month && x.Year == year && x.ProcessedAt == null)
+                    .Lookup<MonthlyStreamCount, Recording, MonthlyStreamCountProjection>(
+                        _unitOfWork.GetCollection<Recording>(),
+                        x => x.TrackId,
+                        x => x.TrackId,
+                        x => x.RecordingProjection)
+                    .Lookup<MonthlyStreamCountProjection, Work, MonthlyStreamCountProjection>(
+                        _unitOfWork.GetCollection<Work>(),
+                        x => x.TrackId,
+                        x => x.TrackId,
+                        x => x.WorkProjection)
+                    .ToListAsync(ct);
 
             foreach (MonthlyStreamCountProjection monthlyStreamCountProjection in monthlyStreamCountProjections)
             {
@@ -80,7 +78,7 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
 
                 // Nếu có RecordingId → áp dụng RecordingSplits
                 decimal recordingPool = totalRoyalty * recordingRoyaltyPercentage;
-                if (!string.IsNullOrEmpty(monthlyStreamCountProjection.RecordingId))
+                if (!string.IsNullOrEmpty(monthlyStreamCountProjection.RecordingProjection?.Id))
                 {
                     if (monthlyStreamCountProjection.RecordingProjection != null)
                     {
@@ -89,7 +87,7 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
                         decimal totalPercentage = monthlyStreamCountProjection.RecordingProjection.RecordingSplits.Sum(s => s.Percentage);
                         if (totalPercentage != 100m)
                         {
-                            throw new ConflictCustomException($"Recording splits for {monthlyStreamCountProjection.RecordingId} must equal 100%, but got {totalPercentage}%");
+                            throw new ConflictCustomException($"Recording splits for {monthlyStreamCountProjection.RecordingProjection.Id} must equal 100%, but got {totalPercentage}%");
                         }
 
                         foreach (RecordingSplitProjection split in monthlyStreamCountProjection.RecordingProjection.RecordingSplits)
@@ -109,7 +107,7 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
 
                 // Nếu có WorkId → áp dụng WorkSplits
                 decimal workPool = totalRoyalty * workRoyaltyPercentage;
-                if (!string.IsNullOrEmpty(monthlyStreamCountProjection.WorkId))
+                if (!string.IsNullOrEmpty(monthlyStreamCountProjection.WorkProjection?.Id))
                 {
                     if (monthlyStreamCountProjection.WorkProjection != null)
                     {
@@ -118,7 +116,7 @@ public sealed class RoyaltyReportService(IUnitOfWork unitOfWork, IRedisCacheServ
                         decimal totalPercentage = monthlyStreamCountProjection.WorkProjection.WorkSplits.Sum(s => s.Percentage);
                         if (totalPercentage != 100m)
                         {
-                            throw new ConflictCustomException($"Work splits for {monthlyStreamCountProjection.WorkId} must equal 100%, but got {totalPercentage}%");
+                            throw new ConflictCustomException($"Work splits for {monthlyStreamCountProjection.WorkProjection.Id} must equal 100%, but got {totalPercentage}%");
                         }
 
                         foreach (WorkSplitProjection split in monthlyStreamCountProjection.WorkProjection.WorkSplits)

--- a/EkofyApp.Infrastructure/Services/Works/WorkService.cs
+++ b/EkofyApp.Infrastructure/Services/Works/WorkService.cs
@@ -95,22 +95,6 @@ public sealed class WorkService(IUnitOfWork unitOfWork, IHttpContextAccessor htt
             };
 
             await _unitOfWork.GetCollection<Work>().InsertOneAsync(session, newWork, cancellationToken: cancellationToken);
-
-            // Cập nhật lại MonthlyStreamCount để tham chiếu đến Work mới
-            UpdateDefinition<MonthlyStreamCount> updateDefinition = Builders<MonthlyStreamCount>.Update.Set(x => x.WorkId, newWork.Id);
-            UpdateResult updateMonthlyStreamCount = await _unitOfWork.GetCollection<MonthlyStreamCount>().UpdateOneAsync(session,
-                x => x.TrackId == trackId && x.WorkId == currentWork.Id && x.ProcessedAt == null,
-                updateDefinition,
-                cancellationToken: cancellationToken);
-            if (updateMonthlyStreamCount.MatchedCount == 0)
-            {
-                throw new NotFoundCustomException("Not found monthly stream count with given conditions");
-            }
-
-            if (updateMonthlyStreamCount.ModifiedCount == 0)
-            {
-                throw new ConflictCustomException("Failed to update MonthlyStreamCount works with the new WorkId.");
-            }
         });
     }
 }


### PR DESCRIPTION
Removed RecordingId, WorkId, and Level fields from MonthlyStreamCount and related projections. Updated service and resolver logic to operate solely on TrackId. Adjusted royalty report aggregation to join on TrackId instead of RecordingId/WorkId. Cleaned up related update logic in RecordingService and WorkService.