### PR TITLE
Refactor GraphQL queries to use explicit sorting types

### DIFF
--- a/EkofyApp.Api/GraphQL/GraphQLServer.cs
+++ b/EkofyApp.Api/GraphQL/GraphQLServer.cs
@@ -2,6 +2,12 @@
 using EkofyApp.Api.GraphQL.Mutation;
 using EkofyApp.Api.GraphQL.Query;
 using EkofyApp.Api.GraphQL.Scalars;
+using EkofyApp.Domain.Enums;
+using EkofyApp.Domain.Enums.Artist;
+using EkofyApp.Domain.Enums.BillingPortalConfig;
+using EkofyApp.Domain.Enums.Coupons;
+using EkofyApp.Domain.Enums.Subcriptions;
+using EkofyApp.Domain.Enums.Users;
 using HotChocolate.Types.Pagination;
 using StackExchange.Redis;
 
@@ -45,7 +51,48 @@ public static class GraphQLServer
             // Configuration
             .AddProjections()
             .AddFiltering()
+
+            // Sorting
             .AddSorting()
+            .AddType<EnumType<ArtistRole>>()
+            .AddType<EnumType<ArtistType>>()
+            .AddType<EnumType<BillingPortalConfigStatus>>()
+            .AddType<EnumType<CustomerUpdate>>()
+            .AddType<EnumType<StripeSubscriptionCancelMode>>()
+            .AddType<EnumType<StripeSubscriptionUpdate>>()
+            .AddType<EnumType<CouponDurationType>>()
+            .AddType<EnumType<CouponPurposeType>>()
+            .AddType<EnumType<CouponStatus>>()
+            .AddType<EnumType<SubscriptionCycle>>()
+            .AddType<EnumType<SubscriptionStatus>>()
+            .AddType<EnumType<SubscriptionTier>>()
+            .AddType<EnumType<UserGender>>()
+            .AddType<EnumType<UserRole>>()
+            .AddType<EnumType<UserStatus>>()
+            .AddType<EnumType<AggregationLevel>>()
+            .AddType<EnumType<AlbumType>>()
+            .AddType<EnumType<AudioFormat>>()
+            .AddType<EnumType<CategoryType>>()
+            .AddType<EnumType<CurrencyType>>()
+            .AddType<EnumType<DocumentType>>()
+            .AddType<EnumType<EntitlementValueType>>()
+            .AddType<EnumType<ImageTag>>()
+            .AddType<EnumType<KeyTag>>()
+            .AddType<EnumType<MoodType>>()
+            .AddType<EnumType<PathTag>>()
+            .AddType<EnumType<PaymentMethodType>>()
+            .AddType<EnumType<PaymentStatus>>()
+            .AddType<EnumType<PeriodTime>>()
+            .AddType<EnumType<PolicyStatus>>()
+            .AddType<EnumType<PolicyType>>()
+            .AddType<EnumType<RecordingStatus>>()
+            .AddType<EnumType<ReleaseStatus>>()
+            .AddType<EnumType<RestrictionType>>()
+            .AddType<EnumType<TrackType>>()
+            .AddType<EnumType<TransactionStatus>>()
+            .AddType<EnumType<WorkStatus>>()
+
+            // Paging
             .AddQueryableCursorPagingProvider(defaultProvider: false)
             .AddQueryableOffsetPagingProvider(defaultProvider: true)
             .AddPagingArguments()

--- a/EkofyApp.Api/GraphQL/Query/Artists/ArtistQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Artists/ArtistQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Artists;
 
@@ -15,6 +16,6 @@ public sealed class ArtistQueryExtension : ObjectTypeExtension<ArtistQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<User>();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Categories/CategoryQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Categories/CategoryQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Categories;
 
@@ -10,7 +11,7 @@ public sealed class CategoryQueryExtension : ObjectTypeExtension<CategoryQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Category>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Coupons/CouponQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Coupons/CouponQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Coupons;
 
@@ -11,6 +12,6 @@ public sealed class CouponQueryExtension : ObjectTypeExtension<CouponQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Coupon>();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Entitlements/EntitlementQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Entitlements;
 
@@ -10,7 +11,7 @@ public sealed class EntitlementQueryExtension : ObjectTypeExtension<EntitlementQ
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Entitlement>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Invoices/InvoiceQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Invoices;
 
@@ -10,7 +11,7 @@ public sealed class InvoiceQueryExtension : ObjectTypeExtension<InvoiceQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Invoice>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Listeners/ListenerQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Listeners;
 
@@ -10,7 +11,7 @@ public sealed class ListenerQueryExtension : ObjectTypeExtension<ListenerQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Listener>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/MonthlyStreamCounts/MonthlyStreamCountQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.MonthlyStreamCounts;
 
@@ -10,7 +11,7 @@ public sealed class MonthlyStreamCountQueryExtension : ObjectTypeExtension<Month
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<MonthlyStreamCount>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Playlists/PlaylistQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Playlists;
 
@@ -10,7 +11,7 @@ public sealed class PlaylistQueryExtension : ObjectTypeExtension<PlaylistQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Playlist>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/LegalPolicyQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Policies;
 
@@ -10,7 +11,7 @@ public sealed class LegalPolicyQueryExtension : ObjectTypeExtension<LegalPolicyQ
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<LegalPolicy>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Policies/RoyaltyPolicyQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Policies;
 
@@ -10,7 +11,7 @@ public sealed class RoyaltyPolicyQueryExtension : ObjectTypeExtension<RoyaltyPol
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<RoyaltyPolicy>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Recordings/RecordingQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Recordings/RecordingQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Recordings;
 
@@ -10,12 +11,12 @@ public sealed class RecordingQueryExtension : ObjectTypeExtension<RecordingQuery
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Recording>();
 
-        descriptor.Field(x => x.GetMetadataRecordingUploadRequestAsync(default!))
-            .Authorize(roles: HelperRoleBase.FullRoles)
-            .UseProjection()
-            .UseFiltering()
-            .UseSorting();
+        //descriptor.Field(x => x.GetMetadataRecordingUploadRequestAsync(default!))
+        //    .Authorize(roles: HelperRoleBase.FullRoles)
+        //    .UseProjection()
+        //    .UseFiltering()
+        //    .UseSorting();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/RoyalReports/RoyaltyReportQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.RoyalReports;
 
@@ -10,7 +11,7 @@ public sealed class RoyaltyReportQueryExtension : ObjectTypeExtension<RoyaltyRep
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<RoyaltyPolicy>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionPlanQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
 
@@ -10,7 +11,7 @@ public sealed class SubscriptionPlanQueryExtension : ObjectTypeExtension<Subscri
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<SubscriptionPlan>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Subscriptions/SubscriptionQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Subscriptions;
 
@@ -10,7 +11,7 @@ public sealed class SubscriptionQueryExtension : ObjectTypeExtension<Subscriptio
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Subscription>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Tracks/TrackQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Tracks/TrackQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Tracks;
 
@@ -10,24 +11,23 @@ public class TrackQueryExtension : ObjectTypeExtension<TrackQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Track>();
 
         descriptor.Field(x => x.GetPendingTrackUploadRequestsAsync())
             .Authorize(roles: HelperRoleBase.ModeratorRoles)
             .UseProjection()
-            .UseFiltering()
-            .UseSorting();
+            .UseFiltering();
 
         descriptor.Field(x => x.GetMetadataTrackUploadRequestAsync(default!))
             .Authorize(roles: HelperRoleBase.ModeratorRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Track>();
 
         descriptor.Field(x => x.GetOriginalFileTrackUploadRequest(default!))
             .Authorize(roles: HelperRoleBase.ModeratorRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Track>();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQuery.cs
+++ b/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQuery.cs
@@ -1,5 +1,5 @@
 ﻿using EkofyApp.Application.ServiceInterfaces.Transactions;
-using System.Transactions;
+using EkofyApp.Domain.Entities;
 
 namespace EkofyApp.Api.GraphQL.Query.Transactions;
 

--- a/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Transactions/TransactionQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Transactions;
 
@@ -10,7 +11,7 @@ public sealed class TransactionQueryExtension : ObjectTypeExtension<TransactionQ
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Transaction>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/UserSubscriptions/UserSubscriptionQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.UserSubscriptions;
 
@@ -10,7 +11,7 @@ public sealed class UserSubscriptionQueryExtension : ObjectTypeExtension<UserSub
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<UserSubscription>();
         //.AllowAnonymous();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Users/UserQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Users/UserQueryExtension.cs
@@ -17,12 +17,12 @@ public class UserQueryExtension : ObjectTypeExtension<UserQuery>
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<User>();
 
         descriptor.Field(x => x.GetUserByIdAsync(default!))
             .Authorize(roles: HelperRoleBase.FullRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<User>();
     }
 }

--- a/EkofyApp.Api/GraphQL/Query/Works/WorkQueryExtension.cs
+++ b/EkofyApp.Api/GraphQL/Query/Works/WorkQueryExtension.cs
@@ -1,4 +1,5 @@
-﻿using EkofyApp.Domain.Utils;
+﻿using EkofyApp.Domain.Entities;
+using EkofyApp.Domain.Utils;
 
 namespace EkofyApp.Api.GraphQL.Query.Works;
 
@@ -10,13 +11,13 @@ public sealed class WorkQueryExtension : ObjectTypeExtension<WorkQuery>
             .Authorize(roles: HelperRoleBase.ModeratorRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Work>();
 
         descriptor.Field(x => x.GetMetadataWorkUploadRequestAsync(default!))
             .Authorize(roles: HelperRoleBase.ModeratorRoles)
             .UseProjection()
             .UseFiltering()
-            .UseSorting();
+            .UseSorting<Work>();
 
         // TODO: Artist cũng nên xem được các work của chính mình
     }

--- a/EkofyApp.Application/ServiceInterfaces/Transactions/ITransactionService.cs
+++ b/EkofyApp.Application/ServiceInterfaces/Transactions/ITransactionService.cs
@@ -1,4 +1,4 @@
-﻿using System.Transactions;
+﻿using EkofyApp.Domain.Entities;
 
 namespace EkofyApp.Application.ServiceInterfaces.Transactions;
 public interface ITransactionService

--- a/EkofyApp.Infrastructure/Services/Transactions/TransactionService.cs
+++ b/EkofyApp.Infrastructure/Services/Transactions/TransactionService.cs
@@ -1,7 +1,7 @@
 ﻿using EkofyApp.Application.ServiceInterfaces;
 using EkofyApp.Application.ServiceInterfaces.Transactions;
+using EkofyApp.Domain.Entities;
 using MongoDB.Driver;
-using System.Transactions;
 
 namespace EkofyApp.Infrastructure.Services.Transactions;
 public sealed class TransactionService(IUnitOfWork unitOfWork) : ITransactionService


### PR DESCRIPTION
Updated all GraphQL query extensions to use UseSorting<T>() with explicit entity types for improved type safety and clarity. Added enum type registrations to the GraphQL server for better enum support. Also removed unused System.Transactions imports and replaced them with correct domain entity imports in transaction-related files.