### PR TITLE
Stream HLS segments directly from S3 in controller

### DIFF
--- a/EkofyApp.Api/REST/MediaStreamingController.cs
+++ b/EkofyApp.Api/REST/MediaStreamingController.cs
@@ -71,11 +71,14 @@ public class MediaStreamingController(IAmazonCloudFrontService amazonCloudFrontS
 
     [ApiExplorerSettings(IgnoreApi = true)]
     [AllowAnonymous, HttpGet("{trackId}/{bitrate}/{segment}")]
-    public IActionResult ProxySegment(string trackId, string bitrate, string segment, [FromQuery] string token)
+    public async Task<IActionResult> ProxySegmentAsync(string trackId, string bitrate, string segment, [FromQuery] string token)
     {
         _amazonCloudFrontService.ValidateHlsToken(trackId, token);
 
-        string redirectUrl = _amazonCloudFrontService.GenerateStreamingSignedURL(trackId, bitrate, segment, token);
-        return Redirect(redirectUrl);
+        //string redirectUrl = _amazonCloudFrontService.GenerateStreamingSignedURL(trackId, bitrate, segment, token);
+        //return Redirect(redirectUrl);
+
+        byte[] segmentContent = await _amazonCloudFrontService.GetSegmentContentAsync(trackId, bitrate, segment, token);
+        return File(segmentContent, "application/octet-stream");
     }
 }

--- a/EkofyApp.Application/ThirdPartyServiceInterfaces/AWS/IAmazonCloudFrontService.cs
+++ b/EkofyApp.Application/ThirdPartyServiceInterfaces/AWS/IAmazonCloudFrontService.cs
@@ -11,4 +11,5 @@ public interface IAmazonCloudFrontService
     Task<string> GetBitratePlaylistAsync(string trackId, string bitrate, string token);
     string GenerateStreamingSignedURL(string trackId, string bitrate, string segment, string token);
     string GenerateOriginalSignedURL(string trackId);
+    Task<byte[]> GetSegmentContentAsync(string trackId, string bitrate, string segment, string token);
 }

--- a/EkofyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
+++ b/EkofyApp.Infrastructure/DependencyInjections/DependencyInjection.cs
@@ -544,6 +544,7 @@ public static class DependencyInjection
             {
                 policy.WithOrigins("http://localhost:3000")
                       .WithOrigins("https://localhost:8888")
+                      .WithOrigins("http://127.0.0.1:5500")
                       .AllowCredentials()
                       .AllowAnyMethod()
                       .AllowAnyHeader();

--- a/EkofyApp.Infrastructure/ThirdPartyServices/AWS/AmazonCloudFrontService.cs
+++ b/EkofyApp.Infrastructure/ThirdPartyServices/AWS/AmazonCloudFrontService.cs
@@ -451,4 +451,33 @@ public sealed class AmazonCloudFrontService(IAmazonS3 s3Client, AWSSetting aWSSe
         );
         return signedUrl;
     }
+
+    public async Task<byte[]> GetSegmentContentAsync(string trackId, string bitrate, string segment, string token)
+    {
+        string prefixKeyStreaming = _aWSSettings.ResourcePrefixStreaming;
+
+        // Đường dẫn đến file .ts trong S3
+        string s3Key = $"{prefixKeyStreaming}/{trackId}/{bitrate}/{segment}";
+
+        try
+        {
+            GetObjectRequest request = new()
+            {
+                BucketName = _aWSSettings.BucketName,
+                Key = s3Key
+            };
+
+            using GetObjectResponse response = await _s3Client.GetObjectAsync(request);
+
+            // Đọc toàn bộ content của file .ts
+            using MemoryStream memoryStream = new();
+            await response.ResponseStream.CopyToAsync(memoryStream);
+
+            return memoryStream.ToArray();
+        }
+        catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+        {
+            throw new NotFoundCustomException($"Segment file not found in S3: {s3Key}");
+        }
+    }
 }


### PR DESCRIPTION
Updated MediaStreamingController to stream HLS segment content directly from S3 instead of redirecting to a signed URL. Added GetSegmentContentAsync to IAmazonCloudFrontService and its implementation. Also updated CORS policy to allow requests from http://127.0.0.1:5500.